### PR TITLE
Remove Swagger base path

### DIFF
--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -826,14 +826,25 @@ definitions:
         type: string
         description: Rotten Tomato score of film
       people:
-        type: string
+        type: array
         description: People found in film
+        items:
+          type: string
       species:
-        type: string
+        type: array
         description: Species found in film
+        items:
+          type: string
       locations:
-        type: string
+        type: array
         description: Locations found in film
+        items:
+          type: string
+      vehicles:
+        type: array
+        description: Vehicles found in film
+        items:
+          type: string
       url:
         type: string
         description: URL of film
@@ -859,8 +870,10 @@ definitions:
         type: string
         description: Hair color of the person
       films:
-        type: string
+        type: array
         description: Array of films the person appears in
+        items:
+          type: string
       species:
         type: string
         description: Species the person belongs to
@@ -880,17 +893,21 @@ definitions:
         type: string
         description: Climate of location
       terrain:
-        type: integer
+        type: string
         description: Terrain type of location
       surface_water:
         type: string
         description: Percent of location covered in water
       residents:
-        type: integer
+        type: array
         description: Array of residents in location
+        items:
+          type: string
       films:
-        type: string
-        description: Climate of location
+        type: array
+        description: Array of films the location appears in
+        items:
+          type: string
       url:
         type: integer
         description: Individual URL of the location
@@ -913,11 +930,15 @@ definitions:
         type: string
         description: Hair color of the species
       people:
-        type: string
+        type: array
         description: People belonging to the species
+        items:
+          type: string
       films:
-        type: string
+        type: array
         description: Array of films the species appears in
+        items:
+          type: string
       url:
         type: string
         description: Unique url of the species

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -208,8 +208,7 @@ paths:
           in: path
           description: film `id`
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: fields
           in: query
           description: comma-separated list of fields to include in the response
@@ -337,8 +336,7 @@ paths:
           in: path
           description: person `id`
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: fields
           in: query
           description: comma-separated list of fields to include in the response
@@ -474,8 +472,7 @@ paths:
           in: path
           description: location `id`
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: fields
           in: query
           description: comma-separated list of fields to include in the response
@@ -507,7 +504,7 @@ paths:
               $ref: '#/definitions/Locations'
           examples:
             application/json:
-              id: 1
+              id: 11014596-71b0-4b3e-b8c0-1c4b15f28b9a
               name: Irontown
               climate: Continental
               terrain: Mountain
@@ -607,8 +604,7 @@ paths:
           in: path
           description: film `id`
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: fields
           in: query
           description: comma-separated list of fields to include in the response
@@ -749,8 +745,7 @@ paths:
           in: path
           description: film `id`
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: fields
           in: query
           description: comma-separated list of fields to include in the response
@@ -801,7 +796,7 @@ definitions:
     type: object
     properties:
       id:
-        type: integer
+        type: string
         description: Unique identifier representing a specific film
       title:
         type: string
@@ -876,7 +871,7 @@ definitions:
     type: object
     properties:
       id:
-        type: integer
+        type: string
         description: Unique identifier representing a specific location
       name:
         type: string

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -121,8 +121,6 @@ x-tagGroups:
       - Locations
       - Species
       - Vehicles
-# will be prefixed to all paths
-basePath: /
 produces:
   - application/json
 paths:


### PR DESCRIPTION
When importing the swagger spec into Insomnia or Postman, the `basePath` adds an extra `/` to the URLs, since each of the paths already includes a leading `/`.

For example, the films URL is imported as `https://ghibliapi.herokuapp.com//films` rather than `https://ghibliapi.herokuapp.com/films`

I removed the base path so that the correct paths are imported. This doesn't impact the URLs displayed by redoc (it looks like redoc wasn't including the `basePath`).