### PR TITLE
API response consistency

### DIFF
--- a/data.json
+++ b/data.json
@@ -1125,9 +1125,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a"
         },
         {
             "id": "64a996aa-481e-4627-9624-ab23f59a05a9",
@@ -1142,9 +1140,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/64a996aa-481e-4627-9624-ab23f59a05a9"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/64a996aa-481e-4627-9624-ab23f59a05a9"
         },
         {
             "id": "a8bd9c03-7c80-4a97-b7c0-6a668acaf576",
@@ -1162,9 +1158,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/90b72513-afd4-4570-84de-a56c312fdf81"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/a8bd9c03-7c80-4a97-b7c0-6a668acaf576"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/a8bd9c03-7c80-4a97-b7c0-6a668acaf576"
         },
         {
             "id": "56e423c4-d9a1-44c4-8bdb-1cab45fbf63e",
@@ -1176,9 +1170,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/5fdfb320-2a02-49a7-94ff-5ca418cae602"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/56e423c4-d9a1-44c4-8bdb-1cab45fbf63e"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/56e423c4-d9a1-44c4-8bdb-1cab45fbf63e"
         },
         {
             "id": "660c8c91-bd92-43db-b475-b2df6ca96fec",
@@ -1192,9 +1184,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/58611129-2dbc-4a81-a72f-77ddfc1b1b49"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/660c8c91-bd92-43db-b475-b2df6ca96fec"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/660c8c91-bd92-43db-b475-b2df6ca96fec"
         },
         {
             "id": "6ba60a86-7c74-4ec4-a6f4-7112b5705a2f",
@@ -1208,9 +1198,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/6ba60a86-7c74-4ec4-a6f4-7112b5705a2f"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/6ba60a86-7c74-4ec4-a6f4-7112b5705a2f"
         },
         {
             "id": "fb083a4e-77b2-4623-a2e0-6bbca5bfd5b2",
@@ -1224,9 +1212,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/ea660b10-85c4-4ae3-8a5f-41cea3648e3e"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/fb083a4e-77b2-4623-a2e0-6bbca5bfd5b2"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/fb083a4e-77b2-4623-a2e0-6bbca5bfd5b2"
         },
         {
             "id": "a072ec53-0467-4fac-864f-df234f9c4315",
@@ -1240,9 +1226,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/dc2e6bd1-8156-4886-adff-b39e6043af0c"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/a072ec53-0467-4fac-864f-df234f9c4315"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/a072ec53-0467-4fac-864f-df234f9c4315"
         },
         {
             "id": "682df5c3-b09e-46af-94d1-ae0d17f9b4b6",
@@ -1257,9 +1241,7 @@
                 "https://ghibliapi.herokuapp.com/films/45204234-adfd-45cb-a505-a8e7a676b114",
                 "https://ghibliapi.herokuapp.com/films/578ae244-7750-4d9f-867b-f3cd3d6fecf4"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/682df5c3-b09e-46af-94d1-ae0d17f9b4b6"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/682df5c3-b09e-46af-94d1-ae0d17f9b4b6"
         },
         {
             "id": "26361a2c-32c6-4bd5-ae9c-8e40e17ae28d",
@@ -1273,9 +1255,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/26361a2c-32c6-4bd5-ae9c-8e40e17ae28d"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/26361a2c-32c6-4bd5-ae9c-8e40e17ae28d"
         },
         {
             "id": "42f787d8-1fcb-4d3d-82f2-a74409869368",
@@ -1289,9 +1269,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/ff24da26-a969-4f0e-ba1e-a122ead6c6e3"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/42f787d8-1fcb-4d3d-82f2-a74409869368"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/42f787d8-1fcb-4d3d-82f2-a74409869368"
         },
         {
             "id": "0fafa7a3-64c1-43fe-881b-ecb605c01e09",
@@ -1305,9 +1283,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/0fafa7a3-64c1-43fe-881b-ecb605c01e09"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/0fafa7a3-64c1-43fe-881b-ecb605c01e09"
         },
         {
             "id": "0132f7f6-fd52-4ac3-b5df-c96b609f77b6",
@@ -1321,9 +1297,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/0132f7f6-fd52-4ac3-b5df-c96b609f77b6"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/0132f7f6-fd52-4ac3-b5df-c96b609f77b6"
         },
         {
             "id": "c57fb2cb-ea85-4d73-8808-cf5dcd28c22e",
@@ -1337,9 +1311,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/ea660b10-85c4-4ae3-8a5f-41cea3648e3e"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/c57fb2cb-ea85-4d73-8808-cf5dcd28c22e"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/c57fb2cb-ea85-4d73-8808-cf5dcd28c22e"
         },
         {
             "id": "615aa48d-8673-4117-b35a-79cb67af1897",
@@ -1353,9 +1325,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/615aa48d-8673-4117-b35a-79cb67af1897"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/615aa48d-8673-4117-b35a-79cb67af1897"
         },
         {
             "id": "37d13a96-a03a-451d-8871-80be0495486e",
@@ -1369,9 +1339,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/dc2e6bd1-8156-4886-adff-b39e6043af0c"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/37d13a96-a03a-451d-8871-80be0495486e"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/37d13a96-a03a-451d-8871-80be0495486e"
         },
         {
             "id": "6fc21b76-78fb-4451-98f7-857e32a23e85",
@@ -1385,9 +1353,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/58611129-2dbc-4a81-a72f-77ddfc1b1b49"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/6fc21b76-78fb-4451-98f7-857e32a23e85"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/6fc21b76-78fb-4451-98f7-857e32a23e85"
         },
         {
             "id": "dbeeaecb-7817-4b8b-90ca-edc432d3033e",
@@ -1401,9 +1367,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/4e236f34-b981-41c3-8c65-f8c9000b94e7"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/dbeeaecb-7817-4b8b-90ca-edc432d3033e"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/dbeeaecb-7817-4b8b-90ca-edc432d3033e"
         },
         {
             "id": "34df8f25-8f80-4823-8f01-bf9852039987",
@@ -1417,9 +1381,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/ebbb6b7c-945c-41ee-a792-de0e43191bd8"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/34df8f25-8f80-4823-8f01-bf9852039987"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/34df8f25-8f80-4823-8f01-bf9852039987"
         },
         {
             "id": "62346d33-caa0-4c17-8016-0aca56f3066b",
@@ -1433,9 +1395,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/ea660b10-85c4-4ae3-8a5f-41cea3648e3e"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/62346d33-caa0-4c17-8016-0aca56f3066b"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/62346d33-caa0-4c17-8016-0aca56f3066b"
         },
         {
             "id": "ee897b2a-405e-42b9-bff4-8b51b0f03cab",
@@ -1449,9 +1409,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/58611129-2dbc-4a81-a72f-77ddfc1b1b49"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/ee897b2a-405e-42b9-bff4-8b51b0f03cab"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/ee897b2a-405e-42b9-bff4-8b51b0f03cab"
         },
         {
             "id": "90241c46-d4be-411f-b00a-7561b9dda7b6",
@@ -1465,9 +1423,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/90241c46-d4be-411f-b00a-7561b9dda7b6"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/90241c46-d4be-411f-b00a-7561b9dda7b6"
         },
         {
             "id": "469b14bd-5565-4436-bbed-c2036f42cc99",
@@ -1481,9 +1437,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/469b14bd-5565-4436-bbed-c2036f42cc99"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/469b14bd-5565-4436-bbed-c2036f42cc99"
         },
         {
             "id": "b6bac992-a858-4d57-8477-9652d73caaa1",
@@ -1497,9 +1451,7 @@
             "films": [
                 "https://ghibliapi.herokuapp.com/films/cd3d059c-09f4-4ff3-8d63-bc765a5184fa"
             ],
-            "url": [
-                "https://ghibliapi.herokuapp.com/locations/b6bac992-a858-4d57-8477-9652d73caaa1"
-            ]
+            "url": "https://ghibliapi.herokuapp.com/locations/b6bac992-a858-4d57-8477-9652d73caaa1"
         }
     ],
     "species": [
@@ -1642,7 +1594,9 @@
             "vehicle_class": "Airship",
             "length": "1,000",
             "pilot": "https://ghibliapi.herokuapp.com/people/40c005ce-3725-4f15-8409-3e1b1b14b583",
-            "films": "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe",
+            "films": [
+                "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
+            ],
             "url": "https://ghibliapi.herokuapp.com/vehicles/4e09b023-f650-4747-9ab9-eacf14540cfb"
         },
         {
@@ -1652,7 +1606,9 @@
             "vehicle_class": "Airplane",
             "length": "20",
             "pilot": "https://ghibliapi.herokuapp.com/people/6523068d-f5a9-4150-bf5b-76abe6fb42c3",
-            "films": "https://ghibliapi.herokuapp.com/films/ebbb6b7c-945c-41ee-a792-de0e43191bd8",
+            "films": [
+                "https://ghibliapi.herokuapp.com/films/ebbb6b7c-945c-41ee-a792-de0e43191bd8"
+            ],
             "url": "https://ghibliapi.herokuapp.com/vehicles/d8f893b5-1dd9-41a1-9918-0099c1aa2de8"
         },
         {
@@ -1662,7 +1618,9 @@
             "vehicle_class": "Boat",
             "length": "10",
             "pilot": "https://ghibliapi.herokuapp.com/people/a10f64f3-e0b6-4a94-bf30-87ad8bc51607",
-            "films": "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786",
+            "films": [
+                "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786"
+            ],
             "url": "https://ghibliapi.herokuapp.com/vehicles/923d70c9-8f15-4972-ad53-0128b261d628"
         }
     ]

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -438,9 +438,7 @@ paths:
                 "films": [
                   "https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6"
                 ],
-                "url": [
-                  "https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a"
-                ]
+                "url": "https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a"
               },
               {
                 "id": "11014596-71b0-4b3e-b8c0-1c4b15f28b9a",
@@ -455,9 +453,7 @@ paths:
                 "films": [
                   "https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6"
                 ],
-                "url": [
-                  "https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a"
-                ]
+                "url": "https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a"
               }]
         '400':
           description: Bad request
@@ -509,8 +505,12 @@ paths:
               climate: Continental
               terrain: Mountain
               surface_water: 40
-              residents: [https://ghibliapi.herokuapp.com/people/ba924631-068e-4436-b6de-f3283fa848f0]
-              films: https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6
+              residents: [
+                https://ghibliapi.herokuapp.com/people/ba924631-068e-4436-b6de-f3283fa848f0
+              ]
+              films: [ 
+                https://ghibliapi.herokuapp.com/films/0440483e-ca0e-4120-8c50-4c8cd9b965d6
+              ]
               url: https://ghibliapi.herokuapp.com/locations/11014596-71b0-4b3e-b8c0-1c4b15f28b9a
         '400':
           description: Bad request
@@ -717,7 +717,9 @@ paths:
                   "vehicle_class": "Airship",
                   "length": "1,000",
                   "pilot": "https://ghibliapi.herokuapp.com/people/40c005ce-3725-4f15-8409-3e1b1b14b583",
-                  "films": "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe",
+                  "films": [
+                    "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
+                  ],
                   "url": "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
                 },
                 {
@@ -727,7 +729,9 @@ paths:
                   "vehicle_class": "Airplane",
                   "length": "20",
                   "pilot": "https://ghibliapi.herokuapp.com/people/6523068d-f5a9-4150-bf5b-76abe6fb42c3",
-                  "films": "https://ghibliapi.herokuapp.com/films/ebbb6b7c-945c-41ee-a792-de0e43191bd8",
+                  "films": [
+                    "https://ghibliapi.herokuapp.com/films/ebbb6b7c-945c-41ee-a792-de0e43191bd8"
+                  ],
                   "url": "https://ghibliapi.herokuapp.com/vehicles/d8f893b5-1dd9-41a1-9918-0099c1aa2de8"
                 }
                 ]
@@ -784,7 +788,9 @@ paths:
                   "vehicle_class": "Boat",
                   "length": "10",
                   "pilot": "https://ghibliapi.herokuapp.com/people/a10f64f3-e0b6-4a94-bf30-87ad8bc51607",
-                  "films": "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786",
+                  "films": [
+                    "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786"
+                  ],
                   "url": "https://ghibliapi.herokuapp.com/films/758bf02e-3122-46e0-884e-67cf83df1786"
                 }
         '400':
@@ -909,7 +915,7 @@ definitions:
         items:
           type: string
       url:
-        type: integer
+        type: string
         description: Individual URL of the location
   Species:
     type: object
@@ -964,8 +970,10 @@ definitions:
         type: string
         description: Pilot of the vehicle
       films:
-        type: string
+        type: array
         description: Array of films the vehicle appears in
+        items:
+          type: string
       url:
         type: string
         description: Unique URL of the vehicle

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -180,7 +180,20 @@ paths:
               "producer": "Isao Takahata",
               "release_date": "1986",
               "running_time": "124",
-              "rt_score": "95"
+              "rt_score": "95",
+              "people": [
+                "https://ghibliapi.herokuapp.com/people/"
+              ],
+              "species": [
+                "https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"
+              ],
+              "locations": [
+                "https://ghibliapi.herokuapp.com/locations/"
+              ],
+              "vehicles": [
+                "https://ghibliapi.herokuapp.com/vehicles/"
+              ],
+              "url": "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
               },
               {
               "id": "12cfb892-aac0-4c5b-94af-521852e46d6a",
@@ -192,7 +205,20 @@ paths:
               "producer": "Toru Hara",
               "release_date": "1988",
               "running_time": "89",
-              "rt_score": "97"
+              "rt_score": "97",
+              "people": [
+                "https://ghibliapi.herokuapp.com/people/"
+              ],
+              "species": [
+                "https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"
+              ],
+              "locations": [
+                "https://ghibliapi.herokuapp.com/locations/"
+              ],
+              "vehicles": [
+                "https://ghibliapi.herokuapp.com/vehicles/"
+              ],
+              "url": "https://ghibliapi.herokuapp.com/films/12cfb892-aac0-4c5b-94af-521852e46d6a"
               }]
         '400':
           description: Bad request
@@ -242,11 +268,27 @@ paths:
             application/json:
               id: 2baf70d1-42bb-4437-b551-e5fed5a87abe
               title: Castle in the Sky
+              original_title: "天空の城ラピュタ"
+              original_title_romanised: "Tenkū no shiro Rapyuta"
               description: The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.
               director: Hayao Miyazaki
               producer: Isao Takahata
-              release_date: 1986
-              rt_score: 95
+              release_date: "1986"
+              running_time: "124"
+              rt_score: "95"
+              people: [
+                "https://ghibliapi.herokuapp.com/people/"
+              ]
+              species: [
+                "https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"
+              ]
+              locations: [
+                "https://ghibliapi.herokuapp.com/locations/"
+              ]
+              vehicles: [
+                "https://ghibliapi.herokuapp.com/vehicles/"
+              ]
+              url: "https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
         '400':
           description: Bad request
         '404':
@@ -373,7 +415,9 @@ paths:
               gender: Male
               eye_color: Emerald
               hair_color: Grey
-              films: https://ghibliapi.herokuapp.com/films/90b72513-afd4-4570-84de-a56c312fdf81
+              films: [
+                https://ghibliapi.herokuapp.com/films/90b72513-afd4-4570-84de-a56c312fdf81
+              ]
               species: https://ghibliapi.herokuapp.com/species/603428ba-8a86-4b0b-a9f1-65df6abef3d3
               url: https://ghibliapi.herokuapp.com/people/3042818d-a8bb-4cba-8180-c19249822d57
         '400':
@@ -504,7 +548,7 @@ paths:
               name: Irontown
               climate: Continental
               terrain: Mountain
-              surface_water: 40
+              surface_water: "40"
               residents: [
                 https://ghibliapi.herokuapp.com/people/ba924631-068e-4436-b6de-f3283fa848f0
               ]


### PR DESCRIPTION
For consistency, made the `locations` url field a string and the `vehicles` films field an array, to match the other objects. I noticed this covers one part of issue #14. Also updated swagger examples to match the actual responses. 