### PR TITLE
Prevent from modifying data.length property in the event a single resource is requested to avoid mutating object properties.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -45,8 +45,6 @@ router.render = (req, res) => {
     if (data.constructor === Array) {
       data.length = Math.min(Math.min(query.limit, data.length), maxLimit)
     }
-  } else {
-    data.length = Math.min(defaultLimit, data.length)
   }
   res.jsonp(data)
 }


### PR DESCRIPTION
Fixes #36 